### PR TITLE
Use MDI only icons and Fix #2

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -26,7 +26,6 @@ tmeasday:publish-counts
 check
 email
 less
-planettraining:material-design-icons
 dapearce:material-icons
 service-configuration
 angular:angular-material

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -73,7 +73,6 @@ oauth2@1.1.9
 observe-sequence@1.0.11
 ordered-dict@1.0.7
 pbastowski:angular-babel@1.3.6
-planettraining:material-design-icons@2.2.3
 practicalmeteor:chai@2.1.0_1
 practicalmeteor:loglevel@1.2.0_2
 practicalmeteor:mocha@2.4.5_2

--- a/imports/ui/components/auth/auth.html
+++ b/imports/ui/components/auth/auth.html
@@ -6,7 +6,7 @@
         Register
     </md-button>
     <md-button class="md-button-icon" aria-label="Logout" ng-click="auth.logout()" ng-show="auth.isLoggedIn" aria-label="Logout">
-        <md-icon md-svg-icon="action:ic_exit_to_app_24px"></md-icon>
+        <md-icon class="xs-va-mid xs-fsz-xlg">{{ 'logout' | mdiIconFilter }}</md-icon>
     </md-button>
     <div ng-show="auth.isLoggedIn" class="lg-pt-7">
       {{ auth.currentUser | displayNameFilter }}

--- a/imports/ui/components/auth/auth.js
+++ b/imports/ui/components/auth/auth.js
@@ -9,9 +9,14 @@ import {
 } from 'meteor/accounts-base';
 
 import template from './auth.html';
+
 import {
     name as DisplayNameFilter
 } from '../../filters/displayName/displayNameFilter';
+import {
+    name as MDIIconFilter
+} from '../../filters/mdiIcon/mdiIconFilter';
+
 import {
     name as Login
 } from '../login/login';

--- a/imports/ui/components/login/login.html
+++ b/imports/ui/components/login/login.html
@@ -18,11 +18,11 @@
             </div>
             <div layout="row" layout-fill layout-margin layout-padding layout-wrap layout-align="center">
                 <md-button ng-click="login.loginGoogle()" class="md-raised">
-                    <md-icon class="lg-va-wbm" style="color: #DC4A38;">{{ 'google' | mdiIconFilter }}</md-icon>
+                    <md-icon class="xs-va-wbm" style="color: #DC4A38;">{{ 'google' | mdiIconFilter }}</md-icon>
                     <span>Google</span>
                 </md-button>
                 <md-button class="md-raised" ng-click="login.loginFacebook()">
-                    <md-icon class="lg-va-wbm" style="color: #3F62B4;">{{ 'facebook-box' | mdiIconFilter }}</md-icon>
+                    <md-icon class="xs-va-wbm" style="color: #3F62B4;">{{ 'facebook-box' | mdiIconFilter }}</md-icon>
                     <span>Facebook</span>
                 </md-button>
             </div>

--- a/imports/ui/components/partiesList/partiesList.html
+++ b/imports/ui/components/partiesList/partiesList.html
@@ -13,7 +13,7 @@
             </div>
             <div flex="70" layout="row" layout-align="center center" layout-margin>
                 <md-input-container flex>
-                    <md-icon class="lg-posli-25" md-svg-icon="action:ic_search_24px"></md-icon>
+                    <md-icon class="lg-posli-25 xs-va-mid xs-fsz-xlg">{{ 'magnify' | mdiIconFilter }}</md-icon>
                     <div>
                         <label>Search by Name</label>
                         <input ng-model="partiesList.searchText">

--- a/imports/ui/components/partyAddButton/partyAddButton.html
+++ b/imports/ui/components/partyAddButton/partyAddButton.html
@@ -1,3 +1,3 @@
 <md-button class="md-fab" aria-label="Add new party" ng-click="partyAddButton.open($event)">
-    <md-icon md-svg-icon="content:ic_add_24px"></md-icon>
+    <md-icon class="xs-va-mid xs-fsz-xlg">{{ 'plus' | mdiIconFilter }}</md-icon>
 </md-button>

--- a/imports/ui/components/partyAddButton/partyAddButton.js
+++ b/imports/ui/components/partyAddButton/partyAddButton.js
@@ -3,6 +3,11 @@ import angularMeteor from 'angular-meteor';
 
 import buttonTemplate from './partyAddButton.html';
 import modalTemplate from './partyAddModal.html';
+
+import {
+    name as MDIIconFilter
+} from '../../filters/mdiIcon/mdiIconFilter';
+
 import {
     name as PartyAdd
 } from '../partyAdd/partyAdd';

--- a/imports/ui/components/partyRemove/partyRemove.html
+++ b/imports/ui/components/partyRemove/partyRemove.html
@@ -1,2 +1,1 @@
-<md-icon md-svg-icon="content:ic_clear_24px" ng-click="partyRemove.remove()">
-</md-icon>
+<md-icon class="xs-va-mid xs-fsz-xlg" ng-click="partyRemove.remove()">{{ 'close' | mdiIconFilter }}</md-icon>

--- a/imports/ui/components/partyRemove/partyRemove.js
+++ b/imports/ui/components/partyRemove/partyRemove.js
@@ -2,6 +2,11 @@ import angular from 'angular';
 import angularMeteor from 'angular-meteor';
 
 import template from './partyRemove.html';
+
+import {
+    name as MDIIconFilter
+} from '../../filters/mdiIcon/mdiIconFilter';
+
 import {
     Parties
 } from '../../../api/parties/index';

--- a/imports/ui/components/register/register.html
+++ b/imports/ui/components/register/register.html
@@ -41,11 +41,11 @@
 
             <div layout="row" layout-fill layout-margin layout-padding layout-align="center" layout-wrap>
               <md-button ng-click="register.registerGoogle()" class="md-raised">
-                  <md-icon class="lg-va-wbm" style="color: #DC4A38;">{{ 'google' | mdiIconFilter }}</md-icon>
+                  <md-icon class="xs-va-wbm" style="color: #DC4A38;">{{ 'google' | mdiIconFilter }}</md-icon>
                   <span>Google</span>
               </md-button>
               <md-button ng-click="register.registerFacebook()" class="md-raised">
-                  <md-icon class="lg-va-wbm" style="color: #3F62B4;">{{ 'facebook-box' | mdiIconFilter }}</md-icon>
+                  <md-icon class="xs-va-wbm" style="color: #3F62B4;">{{ 'facebook-box' | mdiIconFilter }}</md-icon>
                   <span>Facebook</span>
               </md-button>
             </div>

--- a/imports/ui/components/socially/socially.js
+++ b/imports/ui/components/socially/socially.js
@@ -49,19 +49,7 @@ function config($locationProvider, $urlRouterProvider, $mdIconProvider, $mdThemi
     const googleIconPath = '/packages/planettraining_material-design-icons/bower_components/material-design-icons/sprites/svg-sprite/';
 
     $mdIconProvider
-        .defaultFontSet('mdi')
-        .iconSet('action',
-            googleIconPath + 'svg-sprite-action.svg')
-        .iconSet('communication',
-            googleIconPath + 'svg-sprite-communication.svg')
-        .iconSet('content',
-            googleIconPath + 'svg-sprite-content.svg')
-        .iconSet('toogle',
-            googleIconPath + 'svg-sprite-toggle.svg')
-        .iconSet('navigation',
-            googleIconPath + 'svg-sprite-navigation.svg')
-        .iconSet('image',
-            googleIconPath + 'svg-sprite-image.svg');
+        .defaultFontSet('mdi');
 
     $mdThemingProvider.theme('default')
         .primaryPalette('deep-orange', {


### PR DESCRIPTION
# Proposed Changes

This fix the issue #2 by removing all Google Material Icons from project and instead, using only Material Design Icons from community.
### Type of changes
- Bug Fix (fix to issue)
### Features Working

The icons are up and running as follow.

![image](https://cloud.githubusercontent.com/assets/5065673/15848281/6a109ec0-2c62-11e6-93e8-d703fac28228.png)
## Further comments

This is a simple change, for performance purposes. Without loading unnecessary libraries, the code run faster.
### Reviewers: @ddspog
